### PR TITLE
Pin Pydantic to v1 for raindrop-io-py compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "feedgen>=1.0.0",
     "raindrop-io-py>=0.4.1",
+    "pydantic<2.0.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
The raindrop-io-py library currently uses Pydantic v1 APIs that are not compatible with Pydantic v2. This pins Pydantic to <2.0.0 until the library is updated to support v2.

Error was: @root_validator usage requires skip_on_failure=True in v2