### PR TITLE
Fix JavaScript embedding and sort feed by newest first

### DIFF
--- a/resources/rss.js
+++ b/resources/rss.js
@@ -2,42 +2,29 @@
  * RSS/Atom Feed Browser Renderer
  * Transforms Atom feed XML into human-readable HTML for browser viewing
  * while maintaining compatibility with RSS readers.
+ *
+ * Based on Jake Archibald's approach: https://jakearchibald.com/2025/making-xml-human-readable-without-xslt/
  */
 
 (function() {
     'use strict';
 
-    // Only run in browser context, not in RSS readers
-    if (typeof window === 'undefined' || typeof document === 'undefined') {
-        return;
-    }
+    const atomNS = 'http://www.w3.org/2005/Atom';
+    const xhtmlNS = 'http://www.w3.org/1999/xhtml';
 
-    // Check if we're viewing XML (not already transformed)
-    if (document.contentType !== 'application/xml' &&
-        document.contentType !== 'text/xml' &&
-        !document.contentType.includes('xml')) {
-        return;
-    }
+    // Get the original XML feed element
+    const feed = document.documentElement;
 
     /**
      * Get text content from XML element, handling namespace
-     * @param {Element} parent - Parent XML element
-     * @param {string} tagName - Tag name to find
-     * @param {string} namespace - XML namespace URI
-     * @returns {string} Text content or empty string
      */
     function getElementText(parent, tagName, namespace) {
         const elements = parent.getElementsByTagNameNS(namespace, tagName);
-        return elements.length > 0 ? elements[0].textContent : '';
+        return elements.length > 0 ? elements[0].textContent.trim() : '';
     }
 
     /**
      * Get attribute value from XML element
-     * @param {Element} parent - Parent XML element
-     * @param {string} tagName - Tag name to find
-     * @param {string} namespace - XML namespace URI
-     * @param {string} attrName - Attribute name
-     * @returns {string} Attribute value or empty string
      */
     function getElementAttribute(parent, tagName, namespace, attrName) {
         const elements = parent.getElementsByTagNameNS(namespace, tagName);
@@ -46,105 +33,136 @@
 
     /**
      * Format ISO datetime string to human-readable format
-     * @param {string} isoString - ISO 8601 datetime string
-     * @returns {string} Formatted date string
      */
     function formatDate(isoString) {
         if (!isoString) return '';
-        // Extract date and time, replace T with space, and limit to 16 chars (YYYY-MM-DD HH:MM)
         return isoString.substring(0, 16).replace('T', ' ');
     }
 
     /**
-     * Transform Atom feed XML to HTML
+     * Create an HTML element with proper namespace
      */
-    function transformFeed() {
-        const atomNS = 'http://www.w3.org/2005/Atom';
-        const feed = document.documentElement;
-
-        // Extract feed metadata
-        const feedTitle = getElementText(feed, 'title', atomNS);
-        const feedSubtitle = getElementText(feed, 'subtitle', atomNS);
-        const feedUpdated = getElementText(feed, 'updated', atomNS);
-
-        // Get base path from current location for assets
-        const currentPath = window.location.pathname;
-        const basePath = currentPath.substring(0, currentPath.lastIndexOf('/') + 1);
-
-        // Build HTML structure
-        const html = `<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>RSS feed preview | ${escapeHtml(feedTitle)}</title>
-    <link rel="stylesheet" href="${basePath}styles.css">
-</head>
-<body>
-    <main>
-        <header>
-            <img src="${basePath}rss.svg" class="rim" style="width:100px" alt="RSS icon">
-            <h1>RSS feed preview</h1>
-            <p class="meta">Updated on ${escapeHtml(formatDate(feedUpdated))}</p>
-            <p>${escapeHtml(feedSubtitle)}</p>
-            <p>Subscribe by copying the URL from the address bar into your newsreader.</p>
-        </header>
-        <h2>Recent blog posts</h2>
-        ${generateEntries(feed, atomNS)}
-    </main>
-</body>
-</html>`;
-
-        // Replace document content
-        document.open();
-        document.write(html);
-        document.close();
-    }
-
-    /**
-     * Generate HTML for feed entries
-     * @param {Element} feed - Feed XML element
-     * @param {string} atomNS - Atom namespace URI
-     * @returns {string} HTML string for all entries
-     */
-    function generateEntries(feed, atomNS) {
-        const entries = feed.getElementsByTagNameNS(atomNS, 'entry');
-        let html = '';
-
-        for (let i = 0; i < entries.length; i++) {
-            const entry = entries[i];
-            const title = getElementText(entry, 'title', atomNS);
-            const link = getElementAttribute(entry, 'link', atomNS, 'href');
-            const published = getElementText(entry, 'published', atomNS);
-            const summary = getElementText(entry, 'summary', atomNS);
-
-            html += `
-        <article>
-            <h3><a href="${escapeHtml(link)}">${escapeHtml(title)}</a></h3>
-            <p class="meta">Published on ${escapeHtml(formatDate(published))}</p>
-            <p>${escapeHtml(summary)}</p>
-        </article>`;
-        }
-
-        return html;
+    function html(tagName) {
+        return document.createElementNS(xhtmlNS, tagName);
     }
 
     /**
      * Escape HTML special characters
-     * @param {string} text - Text to escape
-     * @returns {string} Escaped text
      */
     function escapeHtml(text) {
-        if (!text) return '';
-        const div = document.createElement('div');
+        const div = html('div');
         div.textContent = text;
         return div.innerHTML;
     }
 
-    // Run transformation when DOM is ready
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', transformFeed);
-    } else {
-        transformFeed();
+    // Extract feed metadata
+    const feedTitle = getElementText(feed, 'title', atomNS);
+    const feedSubtitle = getElementText(feed, 'subtitle', atomNS);
+    const feedUpdated = getElementText(feed, 'updated', atomNS);
+
+    // Get base path from current location for assets
+    const currentPath = window.location.pathname;
+    const basePath = currentPath.substring(0, currentPath.lastIndexOf('/') + 1);
+
+    // Create HTML structure
+    const htmlRoot = html('html');
+    htmlRoot.setAttribute('lang', 'en');
+
+    // Head
+    const head = html('head');
+
+    const metaCharset = html('meta');
+    metaCharset.setAttribute('charset', 'utf-8');
+    head.appendChild(metaCharset);
+
+    const metaViewport = html('meta');
+    metaViewport.setAttribute('name', 'viewport');
+    metaViewport.setAttribute('content', 'width=device-width, initial-scale=1');
+    head.appendChild(metaViewport);
+
+    const title = html('title');
+    title.textContent = `RSS feed preview | ${feedTitle}`;
+    head.appendChild(title);
+
+    const link = html('link');
+    link.setAttribute('rel', 'stylesheet');
+    link.setAttribute('href', basePath + 'styles.css');
+    head.appendChild(link);
+
+    htmlRoot.appendChild(head);
+
+    // Body
+    const body = html('body');
+    const main = html('main');
+
+    // Header
+    const header = html('header');
+
+    const img = html('img');
+    img.setAttribute('src', basePath + 'rss.svg');
+    img.setAttribute('class', 'rim');
+    img.setAttribute('style', 'width:100px');
+    img.setAttribute('alt', 'RSS icon');
+    header.appendChild(img);
+
+    const h1 = html('h1');
+    h1.textContent = 'RSS feed preview';
+    header.appendChild(h1);
+
+    const metaPara = html('p');
+    metaPara.setAttribute('class', 'meta');
+    metaPara.textContent = `Updated on ${formatDate(feedUpdated)}`;
+    header.appendChild(metaPara);
+
+    const subtitlePara = html('p');
+    subtitlePara.textContent = feedSubtitle;
+    header.appendChild(subtitlePara);
+
+    const instructionsPara = html('p');
+    instructionsPara.textContent = 'Subscribe by copying the URL from the address bar into your newsreader.';
+    header.appendChild(instructionsPara);
+
+    main.appendChild(header);
+
+    // Entries
+    const h2 = html('h2');
+    h2.textContent = 'Recent blog posts';
+    main.appendChild(h2);
+
+    const entries = feed.getElementsByTagNameNS(atomNS, 'entry');
+    for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        const entryTitle = getElementText(entry, 'title', atomNS);
+        const entryLink = getElementAttribute(entry, 'link', atomNS, 'href');
+        const published = getElementText(entry, 'published', atomNS);
+        const summary = getElementText(entry, 'summary', atomNS);
+
+        const article = html('article');
+
+        const h3 = html('h3');
+        const a = html('a');
+        a.setAttribute('href', entryLink);
+        a.textContent = entryTitle;
+        h3.appendChild(a);
+        article.appendChild(h3);
+
+        const datePara = html('p');
+        datePara.setAttribute('class', 'meta');
+        datePara.textContent = `Published on ${formatDate(published)}`;
+        article.appendChild(datePara);
+
+        if (summary) {
+            const summaryPara = html('p');
+            summaryPara.textContent = summary;
+            article.appendChild(summaryPara);
+        }
+
+        main.appendChild(article);
     }
+
+    body.appendChild(main);
+    htmlRoot.appendChild(body);
+
+    // Replace the XML root with the HTML root
+    document.replaceChild(htmlRoot, document.documentElement);
 })();


### PR DESCRIPTION
Implemented Jake Archibald's technique for making XML human-readable without XSLT (https://jakearchibald.com/2025/making-xml-human-readable-without-xslt/)

Two critical fixes:

1. **Use external JavaScript with XHTML namespace**
   - Changed from inline embedded JS to external script reference
   - Added xmlns="http://www.w3.org/1999/xhtml" attribute to script tag
   - Added defer="" attribute for proper loading
   - JavaScript now uses createElementNS to create proper HTML elements
   - Script replaces entire XML document with HTML structure
   - This works in Chromium-based browsers (Vivaldi, Chrome, Edge, etc.)

2. **Sort feed entries by newest first**
   - Changed SQL query from ORDER BY id to ORDER BY id DESC
   - Feed now shows most recent entries at the top
   - More intuitive for RSS readers and web browsers

How it works:
- Feed contains: <script xmlns="http://www.w3.org/1999/xhtml" src="rss.js" defer="">
- Browser loads the script and executes it
- Script reads XML data from document.documentElement
- Creates HTML structure using document.createElementNS
- Replaces document root with new HTML root
- RSS readers ignore the script tag and parse feed normally

Feed remains valid Atom 1.0 and fully compatible with RSS readers.