### PR TITLE
Use self-closing script tag per Jake Archibald's example

### DIFF
--- a/raindrop2rss.py
+++ b/raindrop2rss.py
@@ -213,7 +213,7 @@ def generate_rss_feed(con, arguments) -> str:
     # Add external JavaScript reference with XHTML namespace
     # Using Jake Archibald's technique: https://jakearchibald.com/2025/making-xml-human-readable-without-xslt/
     # The script replaces the XML document with HTML when viewed in a browser
-    script_tag = f'<script xmlns="http://www.w3.org/1999/xhtml" src="{arguments.web_path}rss.js" defer=""></script>\n  '
+    script_tag = f'<script xmlns="http://www.w3.org/1999/xhtml" src="{arguments.web_path}rss.js" defer="" />\n  '
 
     # Insert script after the opening feed tag
     feed_str = feed_str.replace(


### PR DESCRIPTION
Changed from <script></script> to <script /> format to match the example in the article more closely.