### PR TITLE
Add console debugging to diagnose feed parsing issue

### DIFF
--- a/resources/rss.js
+++ b/resources/rss.js
@@ -60,6 +60,13 @@
     const feedSubtitle = getElementText(feed, 'subtitle', atomNS);
     const feedUpdated = getElementText(feed, 'updated', atomNS);
 
+    // Debug: Log what we found
+    console.log('Feed element:', feed.tagName);
+    console.log('Feed title:', feedTitle);
+    console.log('Feed subtitle:', feedSubtitle);
+    console.log('Feed updated:', feedUpdated);
+    console.log('Number of entries:', feed.getElementsByTagNameNS(atomNS, 'entry').length);
+
     // Get base path from current location for assets
     const currentPath = window.location.pathname;
     const basePath = currentPath.substring(0, currentPath.lastIndexOf('/') + 1);


### PR DESCRIPTION
Added console.log statements to see:
- What feed element we're working with
- Whether feed metadata is being extracted
- How many entries are found

This will help diagnose why the HTML is empty.