### PR TITLE
Wait for DOMContentLoaded before transforming feed

### DIFF
--- a/resources/rss.js
+++ b/resources/rss.js
@@ -9,11 +9,20 @@
 (function() {
     'use strict';
 
-    const atomNS = 'http://www.w3.org/2005/Atom';
-    const xhtmlNS = 'http://www.w3.org/1999/xhtml';
+    // Wait for the entire document to be loaded before transforming
+    // In XML documents, defer doesn't work like HTML, so we need to wait
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', transformFeed);
+    } else {
+        transformFeed();
+    }
 
-    // Get the original XML feed element
-    const feed = document.documentElement;
+    function transformFeed() {
+        const atomNS = 'http://www.w3.org/2005/Atom';
+        const xhtmlNS = 'http://www.w3.org/1999/xhtml';
+
+        // Get the original XML feed element
+        const feed = document.documentElement;
 
     /**
      * Get text content from XML element, handling namespace
@@ -183,4 +192,5 @@
 
     // Replace the XML root with the HTML root
     document.replaceChild(htmlRoot, document.documentElement);
+    }
 })();


### PR DESCRIPTION
The script was running before the XML document was fully parsed, so the feed element only had the script tag as a child.

In XML documents, 'defer' attribute doesn't work like in HTML. We need to explicitly wait for DOMContentLoaded event to ensure all feed elements are loaded before we try to transform them.

This should fix the issue where feed entries weren't showing up.