### PR TITLE
Fix super-linter permissions to resolve 403 Status API error

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,6 +13,9 @@ on:
 
 permissions:
   contents: read
+  statuses: write
+  checks: write
+  pull-requests: write
 
 # A workflow run is made up of one or more jobs that can run sequentially
 # or in parallel


### PR DESCRIPTION
Added required permissions for super-linter v8:
- statuses: write - Allows posting commit statuses
- checks: write - Allows creating check runs
- pull-requests: write - Allows commenting on PRs

The 403 error occurred because super-linter v8 tries to post status updates to GitHub's Status API, but the workflow only had contents:read.

Super-linter v8 requires these additional permissions to:
1. Post linting status to commits
2. Create check runs with detailed results
3. Add review comments to pull requests

This is standard for super-linter v8 and matches the recommended configuration from the super-linter documentation.