### PR TITLE
Disable JAVASCRIPT_PRETTIER, BIOME_FORMAT, and BIOME_LINT

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -42,9 +42,13 @@ jobs:
         env:
           FILTER_REGEX_EXCLUDE: CHANGELOG.md
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
           VALIDATE_CSS: false
           VALIDATE_CSS_PRETTIER: false
+          VALIDATE_JAVASCRIPT_PRETTIER: false
           VALIDATE_JSCPD: false
+          VALIDATE_JSON_PRETTIER: false
           VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_NATURAL_LANGUAGE: false
           VALIDATE_PYTHON_BLACK: false
@@ -53,4 +57,3 @@ jobs:
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_PYTHON_PYINK: false
           VALIDATE_PYTHON_PYLINT: false
-          VALIDATE_JSON_PRETTIER: false


### PR DESCRIPTION
These formatters/linters have conflicting opinions about code style and are not needed for the project. The code is already validated by:
- JavaScript Standard (for JS)
- YAML linter (for workflows)
- Markdown linter (for docs)

Disabled:
- VALIDATE_JAVASCRIPT_PRETTIER: false
- VALIDATE_BIOME_FORMAT: false
- VALIDATE_BIOME_LINT: false

This keeps essential linting while removing opinionated formatters.