### PR TITLE
Disable ruff format in CI pipeline

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -57,3 +57,5 @@ jobs:
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_PYTHON_PYINK: false
           VALIDATE_PYTHON_PYLINT: false
+          # TODO: Re-enable after next super-linter update
+          VALIDATE_PYTHON_RUFF_FORMAT: false


### PR DESCRIPTION
Add VALIDATE_PYTHON_RUFF_FORMAT: false to disable ruff format checks in super-linter. Added TODO to re-enable after next super-linter update.